### PR TITLE
Adding delimiters to solve key error

### DIFF
--- a/train.py
+++ b/train.py
@@ -40,6 +40,9 @@ def default_config():
     num_beam_paths = 2
     training_params = TrainingParams().to_dict()
     restore_model = False
+    csv_delimiter = ';'
+    string_split_delimiter = '|'
+    
 
 
 @ex.automain


### PR DESCRIPTION
Sacred config gives out key error, saying delimiters are never used. Adding them in default_config() solves the issue.